### PR TITLE
fix: let image layer be either interactive or not

### DIFF
--- a/BlazorLeaflet/BlazorLeaflet.Samples/Pages/MapPage.razor
+++ b/BlazorLeaflet/BlazorLeaflet.Samples/Pages/MapPage.razor
@@ -1,0 +1,14 @@
+@page "/interactive"
+<h3>MapPage</h3>
+
+<input type="checkbox" id="interactive" @bind="@_imgLayer.IsInteractive" @onclick="ToggleInteractive"/>
+<label for="interactive">Interaktiv</label>
+
+<PageTitle>Index</PageTitle>
+
+@if (Map != null)
+{
+    <div id="mapContainer" style="width: 100%; height: 500px;">
+        <LeafletMap Map="Map"/>
+    </div>
+}

--- a/BlazorLeaflet/BlazorLeaflet.Samples/Pages/MapPage.razor.cs
+++ b/BlazorLeaflet/BlazorLeaflet.Samples/Pages/MapPage.razor.cs
@@ -1,0 +1,50 @@
+using System.Drawing;
+using BlazorLeaflet.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorLeaflet.Samples.Pages;
+
+public partial class MapPage
+{
+    [Inject] IJSRuntime JsRuntime { get; set; } = default!;
+    private Map? Map { get; set; }
+
+    private readonly ImageLayer _imgLayer = new("/img/placio.jpg",
+        new PointF(54.30965067305515f, 9.671299274981452f),
+        new PointF(54.30945977542981f, 9.672376576355745f))
+    {
+        IsInteractive = false
+    };
+
+    protected override void OnInitialized()
+    {
+        Map = new Map(JsRuntime)
+        {
+            Center = new LatLng(54.3096351f, 9.6714511f),
+            Zoom = 14f,
+            MaxZoom = 19f
+        };
+
+        Map.OnInitialized += () =>
+        {
+            Map.AddLayer(new TileLayer
+            {
+                UrlTemplate = "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                Attribution =
+                    "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+                MaximumZoom = 19f
+            });
+
+            Map.AddLayer(_imgLayer);
+        };
+        Map.OnBoundsChanged += (s, e) => StateHasChanged();
+    }
+
+    private void ToggleInteractive()
+    {
+        Map!.RemoveLayer(_imgLayer);
+        _imgLayer.IsInteractive = !_imgLayer.IsInteractive;
+        Map.AddLayer(_imgLayer);
+    }
+}

--- a/BlazorLeaflet/BlazorLeaflet.Samples/Shared/NavMenu.razor
+++ b/BlazorLeaflet/BlazorLeaflet.Samples/Shared/NavMenu.razor
@@ -1,45 +1,50 @@
 ﻿<div class="top-row ps-3 navbar navbar-dark">
-	<div class="container-fluid">
-		<a class="navbar-brand" href="">BlazorLeaflet.Samples</a>
-		<button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-			<span class="navbar-toggler-icon"></span>
-		</button>
-	</div>
+    <div class="container-fluid">
+        <a class="navbar-brand" href="">BlazorLeaflet.Samples</a>
+        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    </div>
 </div>
 
 <div class="@NavMenuCssClass" @onclick="ToggleNavMenu">
-	<nav class="flex-column">
-		<div class="nav-item px-3">
-			<NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-				<span class="oi oi-home" aria-hidden="true"></span> Home
-			</NavLink>
-		</div>
-		<div class="nav-item px-3">
-			<NavLink class="nav-link" href="shapes">
-				<span class="oi oi-plus" aria-hidden="true"></span> Shapes
-			</NavLink>
-		</div>
-		<div class="nav-item px-3">
-			<NavLink class="nav-link" href="rotated">
-				<span class="oi oi-list-rich" aria-hidden="true"></span> Rotated Image Overlay
-			</NavLink>
-		</div>
-		<div class="nav-item px-3">
-			<NavLink class="nav-link" href="customcontrols">
-				<span class="oi oi-list-rich" aria-hidden="true"></span> Custom Controls
-			</NavLink>
-		</div>
-	</nav>
+    <nav class="flex-column">
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                <span class="oi oi-home" aria-hidden="true"></span> Home
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="shapes">
+                <span class="oi oi-plus" aria-hidden="true"></span> Shapes
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="rotated">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Rotated Image Overlay
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="interactive">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Test Interactive Layer
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="customcontrols">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Custom Controls
+            </NavLink>
+        </div>
+    </nav>
 </div>
 
 @code {
-	private bool collapseNavMenu = true;
+    private bool collapseNavMenu = true;
 
-	private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+    private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
-	private void ToggleNavMenu()
-	{
-		collapseNavMenu = !collapseNavMenu;
-	}
+    private void ToggleNavMenu()
+    {
+        collapseNavMenu = !collapseNavMenu;
+    }
 
 }

--- a/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
+++ b/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
@@ -143,7 +143,8 @@ window.leafletBlazor = {
 		const bounds = L.latLngBounds(corner1, corner2);
 
 		const imgLayer = L.imageOverlay(image.url, bounds, layerOptions);
-		addLayer(mapId, imgLayer);
+		connectInteractiveLayerEvents(imgLayer, objectReference);
+		addLayer(mapId, imgLayer, image.id);
 	},
 	addImageRotatedLayer: function (mapId, image, objectReference) {
 		const layerOptions = {
@@ -162,7 +163,8 @@ window.leafletBlazor = {
 		
 
 		const imgLayer = L.imageOverlay.rotated(image.url, corner1, corner2, corner3, layerOptions);
-		addLayer(mapId, imgLayer);
+		connectInteractiveLayerEvents(imgLayer, objectReference);
+		addLayer(mapId, imgLayer, image.id);
 	},
 	addGeoJsonLayer: function (mapId, geodata, objectReference) {
 		const geoDataObject = JSON.parse(geodata.geoJsonData);


### PR DESCRIPTION
The leafletBlazorInterops.js missed code that ensures that image layer can be interactive or not by using a specific boolean value.